### PR TITLE
CLOUD-2235 add jboss-kie-modules module repository

### DIFF
--- a/businesscentral/image.yaml
+++ b/businesscentral/image.yaml
@@ -298,8 +298,8 @@ modules:
           - name: os-eap-extensions
           - name: openshift-layer
           - name: openshift-passwd
-          - name: os-bpmsuite-common
-          - name: os-bpmsuite-businesscentral
+          - name: os.bpmsuite.common
+          - name: os.bpmsuite.businesscentral
           - name: jboss-maven
 packages:
       repositories:

--- a/businesscentral/image.yaml
+++ b/businesscentral/image.yaml
@@ -264,8 +264,11 @@ ports:
 modules:
       repositories:
           - git:
-                  url: https://github.com/jboss-openshift/cct_module.git
-                  ref: master
+              url: https://github.com/jboss-openshift/cct_module.git
+              ref: master
+          - git:
+              url: https://github.com/jboss-container-images/jboss-kie-modules.git
+              ref: master
       install:
           - name: dynamic-resources
           - name: s2i-common

--- a/controller/image.yaml
+++ b/controller/image.yaml
@@ -238,8 +238,8 @@ modules:
           - name: os-eap-extensions
           - name: openshift-layer
           - name: openshift-passwd
-          - name: os-bpmsuite-common
-          - name: os-bpmsuite-standalonecontroller
+          - name: os.bpmsuite.common
+          - name: os.bpmsuite.standalonecontroller
 packages:
       repositories:
           - jboss-os

--- a/controller/image.yaml
+++ b/controller/image.yaml
@@ -204,8 +204,11 @@ ports:
 modules:
       repositories:
           - git:
-                  url: https://github.com/jboss-openshift/cct_module.git
-                  ref: master
+              url: https://github.com/jboss-openshift/cct_module.git
+              ref: master
+          - git:
+              url: https://github.com/jboss-container-images/jboss-kie-modules.git
+              ref: master
       install:
           - name: dynamic-resources
           - name: s2i-common

--- a/kieserver/image.yaml
+++ b/kieserver/image.yaml
@@ -364,8 +364,8 @@ modules:
           - name: os-eap-extensions
           - name: openshift-layer
           - name: openshift-passwd
-          - name: os-bpmsuite-common
-          - name: os-bpmsuite-executionserver
+          - name: os.bpmsuite.common
+          - name: os.bpmsuite.executionserver
           - name: jboss-maven
 packages:
       repositories:

--- a/kieserver/image.yaml
+++ b/kieserver/image.yaml
@@ -329,8 +329,11 @@ ports:
 modules:
       repositories:
           - git:
-                  url: https://github.com/jboss-openshift/cct_module.git
-                  ref: master
+              url: https://github.com/jboss-openshift/cct_module.git
+              ref: master
+          - git:
+              url: https://github.com/jboss-container-images/jboss-kie-modules.git
+              ref: master
       install:
           - name: dynamic-resources
           - name: s2i-common

--- a/smartrouter/image.yaml
+++ b/smartrouter/image.yaml
@@ -58,8 +58,11 @@ ports:
 modules:
       repositories:
           - git:
-                  url: https://github.com/jboss-openshift/cct_module.git
-                  ref: master
+              url: https://github.com/jboss-openshift/cct_module.git
+              ref: master
+          - git:
+              url: https://github.com/jboss-container-images/jboss-kie-modules.git
+              ref: master
       install:
           - name: os-bpmsuite-smartrouter
           - name: jboss-maven

--- a/smartrouter/image.yaml
+++ b/smartrouter/image.yaml
@@ -64,7 +64,7 @@ modules:
               url: https://github.com/jboss-container-images/jboss-kie-modules.git
               ref: master
       install:
-          - name: os-bpmsuite-smartrouter
+          - name: os.bpmsuite.smartrouter
           - name: jboss-maven
 artifacts:
     - url: https://maven.repository.redhat.com/ga/org/slf4j/slf4j-simple/1.7.7.redhat-2/slf4j-simple-1.7.7.redhat-2.jar


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2235

The KIE modules are moving from cct_module to the jboss-kie-modules
repository. Add this to our list of module repositories.